### PR TITLE
chore: reference main branch of google-cloud-python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Python Client for App Engine Admin
 - `Product Documentation`_
 
 .. |GA| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#general-availability
+   :target: https://github.com/googleapis/google-cloud-python/blob/main/README.rst#general-availability
 .. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-appengine-admin.svg
    :target: https://pypi.org/project/google-cloud-appengine-admin/
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-admin.svg
@@ -79,4 +79,4 @@ Next Steps
    APIs that we cover.
 
 .. _App Engine Admin Product documentation:  https://cloud.google.com/appengine/docs/admin-api/
-.. _README: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst


### PR DESCRIPTION
Adjust google-cloud-python links to reference main branch.