### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "appengine",
     "name_pretty": "App Engine Admin API",
     "product_documentation": "https://cloud.google.com/appengine/docs/admin-api/",
-    "client_documentation": "https://googleapis.dev/python/appengine/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/appengine/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for App Engine Admin
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-appengine-admin.svg
    :target: https://pypi.org/project/google-cloud-appengine-admin/
 .. _App Engine Admin: https://cloud.google.com/appengine/docs/admin-api/
-.. _Client Library Documentation: https://googleapis.dev/python/appengine/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/appengine/latest
 .. _Product Documentation:  https://cloud.google.com/appengine/docs/admin-api/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.